### PR TITLE
Remove '<' from response

### DIFF
--- a/lib/ghci.coffee
+++ b/lib/ghci.coffee
@@ -55,7 +55,7 @@ class GHCI
             @finished = true
 
             if @response
-              @responseBuffer = @responseBuffer.map((line) -> "< #{line}")
+              @responseBuffer = @responseBuffer.map((line) -> "#{line}")
 
             # TODO: Show that command finished
             @emitter.emit 'error', @errorBuffer.join(EOL) + EOL


### PR DESCRIPTION
IMHO the less-than sign in the response adds a lot of visual clutter and takes up valuable space on smaller screens. What I mean is:

``` haskell
> putStrLn "Hello, world!"
< Hello, world!
```

vs.

``` haskell
> putStrLn "Hello, world!"
Hello, world!
```

I've modified the source to make the output look like the latter.
