### PR TITLE
Quote the path for ghci-wrapper under Windows

### DIFF
--- a/lib/ghci.coffee
+++ b/lib/ghci.coffee
@@ -35,7 +35,7 @@ class GHCI
         if process.platform is 'win32'
           spawnArgs = [command, args...]
           if cmdexe = atom.config.get('ide-haskell-repl.ghciWrapperPath')
-            spawnArgs.unshift(cmdexe)
+            spawnArgs.unshift("\"" + cmdexe + "\"")
           CP.spawn "chcp 65001 && ", spawnArgs,
             cwd: cwd
             stdio: ['pipe', 'pipe', 'pipe']


### PR DESCRIPTION
Quote the path for ghci-wrapper, so path with spaces can correctly use.